### PR TITLE
#4 Refactor logging and migrate to Java modules system

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -194,6 +194,7 @@
       <githubArtifactURL>
          <![CDATA[https://github.com/Bernardo-MG?tab=packages&amp;repo_name=picocli-manifest-version-provider]]>
       </githubArtifactURL>
+      <maven.compiler.release>${maven.compiler.source}</maven.compiler.release>
    </properties>
 
    <!-- ********************************************** -->
@@ -219,16 +220,6 @@
          <groupId>info.picocli</groupId>
          <artifactId>picocli</artifactId>
          <version>${picocli.version}</version>
-      </dependency>
-      <!-- ============================================== -->
-      <!-- ================== LOMBOK ==================== -->
-      <!-- ============================================== -->
-      <dependency>
-         <!-- Lombok -->
-         <groupId>org.projectlombok</groupId>
-         <artifactId>lombok</artifactId>
-         <version>${lombok.version}</version>
-         <scope>provided</scope>
       </dependency>
       <!-- ============================================== -->
       <!-- ================== LOGGERS =================== -->
@@ -284,6 +275,58 @@
    <build>
       <defaultGoal>clean package</defaultGoal>
       <plugins>
+         <plugin>
+            <!-- Dependency -->
+            <!-- Copies the dependencies to the module path directory -->
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <executions>
+               <execution>
+                  <id>copy-dependencies</id>
+                  <phase>generate-resources</phase>
+                  <goals>
+                     <goal>copy-dependencies</goal>
+                  </goals>
+                  <configuration>
+                     <outputDirectory>${project.build.directory}/modules</outputDirectory>
+                     <includeScope>runtime</includeScope>
+                  </configuration>
+               </execution>
+            </executions>
+         </plugin>
+         <plugin>
+            <!-- Compiler -->
+            <!-- Configures the compiler -->
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+               <!-- Configure the module path directory -->
+               <compilerArgs>
+                  <arg>-proc:none</arg>
+                  <arg>--module-path</arg>
+                  <arg>${project.build.directory}/modules</arg>
+               </compilerArgs>
+            </configuration>
+            <executions>
+               <!-- Configure test compilation for modules -->
+               <execution>
+                  <id>default-testCompile</id>
+                  <phase>test-compile</phase>
+                  <goals>
+                     <goal>testCompile</goal>
+                  </goals>
+                  <configuration>
+                     <compilerArgs>
+                        <arg>-proc:none</arg>
+                        <arg>--module-path</arg>
+                        <arg>${project.build.directory}/modules${path.separator}${project.build.directory}/classes</arg>
+                     </compilerArgs>
+                  </configuration>
+               </execution>
+
+            </executions>
+
+         </plugin>
          <plugin>
             <!-- Changes -->
             <!-- Takes care of the changes log -->

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
    <groupId>com.bernardomg.cli</groupId>
    <artifactId>picocli-manifest-version-provider</artifactId>
-   <version>1.0.0-SNAPSHOT</version>
+   <version>1.0.0</version>
    <packaging>jar</packaging>
 
    <name>picocli Manifest Version Provider</name>

--- a/src/main/java/com/bernardomg/cli/picocli/version/AbstractManifestVersionProvider.java
+++ b/src/main/java/com/bernardomg/cli/picocli/version/AbstractManifestVersionProvider.java
@@ -24,7 +24,8 @@ import java.util.Optional;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 
-import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import picocli.CommandLine.IVersionProvider;
 
 /**
@@ -34,8 +35,12 @@ import picocli.CommandLine.IVersionProvider;
  * @author Bernardo Mart&iacute;nez Garrido
  *
  */
-@Slf4j
 public abstract class AbstractManifestVersionProvider implements IVersionProvider {
+
+    /**
+     * Logger for the class.
+     */
+    private static final Logger log = LoggerFactory.getLogger(AbstractManifestVersionProvider.class);
 
     /**
      * Manifest implementation title key.
@@ -91,7 +96,7 @@ public abstract class AbstractManifestVersionProvider implements IVersionProvide
 
         // Searches for version
         version = Optional.empty();
-        while ((!version.isPresent()) && (resources.hasMoreElements())) {
+        while ((version.isEmpty()) && (resources.hasMoreElements())) {
             final Optional<Manifest> manifest;
             final Attributes         attr;
 
@@ -130,10 +135,10 @@ public abstract class AbstractManifestVersionProvider implements IVersionProvide
      *            URL to the manifest file
      * @return the manifest structure
      */
-    private final Optional<Manifest> getManifest(final URL url) {
+    private Optional<Manifest> getManifest(final URL url) {
         final Manifest     manifest;
         Optional<Manifest> result;
-        
+
         log.debug("Reading manifest from {}", url);
 
         try {
@@ -160,7 +165,7 @@ public abstract class AbstractManifestVersionProvider implements IVersionProvide
      *            attributes with the version
      * @return the implementation version
      */
-    private final String getVersion(final Attributes attr) {
+    private String getVersion(final Attributes attr) {
         final StringBuilder version;
 
         version = new StringBuilder();
@@ -185,10 +190,10 @@ public abstract class AbstractManifestVersionProvider implements IVersionProvide
      *            manifest to check
      * @return {@code true} if it is the expected manifest, {@code false} in other case
      */
-    private final Boolean isValid(final Manifest manifest) {
+    private boolean isValid(final Manifest manifest) {
         final Attributes attributes;
         final Object     title;
-        final Boolean    valid;
+        final boolean valid;
 
         attributes = manifest.getMainAttributes();
 

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,7 @@
+module com.bernardomg.cli.picocli.version {
+    exports com.bernardomg.cli.picocli.version;
+
+    requires info.picocli;
+    requires java.base;
+    requires org.slf4j;
+}


### PR DESCRIPTION
- Replaced Lombok's `@Slf4j` with manual `org.slf4j.Logger` implementation.
- Introduced a `module-info.java` file to define the module system.
- Updated `pom.xml` to remove Lombok dependency and configure module-related Maven plugins.